### PR TITLE
Add credits field to mods.toml and clean up imports in Window.java

### DIFF
--- a/src/main/java/us/minecraftchest2/hdm_mod/block/custom/Window.java
+++ b/src/main/java/us/minecraftchest2/hdm_mod/block/custom/Window.java
@@ -17,12 +17,10 @@ import net.minecraft.util.math.shapes.IBooleanFunction;
 import net.minecraft.util.math.shapes.ISelectionContext;
 import net.minecraft.util.math.shapes.VoxelShape;
 import net.minecraft.util.math.shapes.VoxelShapes;
-import net.minecraft.util.text.ITextComponent;
 import net.minecraft.util.text.StringTextComponent;
 import net.minecraft.world.IBlockReader;
 import net.minecraft.world.World;
 import net.minecraft.world.server.ServerWorld;
-//import us.minecraftchest2.hdm_mod.world.dimension.ModDimensions;
 import us.minecraftchest2.hdm_mod.world.dimension.ModDimensions;
 import us.minecraftchest2.hdm_mod.world.dimension.SimpleTeleporter;
 

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -30,6 +30,7 @@ displayName = "${mod_name}" #mandatory
 #credits="Thanks for this example mod goes to Java" #optional
 # A text field displayed in the mod UI
 authors = "${mod_authors}" #optional
+credits="${credits}"
 # The description text for the mod (multi line!) (#mandatory)
 description = '''${mod_description}'''
 # A dependency - use the . to indicate dependency for a specific modid. Dependencies are optional.


### PR DESCRIPTION
The mods.toml file now includes a credits field so it shows up in the mod list. Additionally, unused imports in Window.java were removed to improve code readability and maintainability.